### PR TITLE
Validator scheduling

### DIFF
--- a/QUICKSTART_TESTNET.md
+++ b/QUICKSTART_TESTNET.md
@@ -175,3 +175,4 @@ To make this work you need to set environment variables:
 - **NETWORK_UID** - Set to 222 (Solidity Audit network)
 - **NETWORK_TYPE** - Set to `test`
 - **CHAIN_ENDPOINT** - Set to `wss://test.finney.opentensor.ai:443/`
+- **VALIDATOR_TIME** - value from 0 to 59, indicates executable validator minute in hour

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       WORKER_TYPE: 'validator'
       BT_AXON_PORT: 8100
       COLDKEY_DESCRIPTION: ''
+      VALIDATOR_TIME: ${VALIDATOR_TIME}
     restart: unless-stopped
     networks:
       - solidity-audit

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -45,6 +45,12 @@ class Validator(ReinforcedValidatorNeuron):
     def __init__(self, config=None):
         self._step = 0
         self._start_time = time.time()
+        self._validator_time_min = (
+            int(os.getenv("VALIDATOR_TIME"))
+            if 0 <= int(os.getenv("VALIDATOR_TIME", -1)) <= 59
+            else None
+        )
+
         super().__init__(config=config)
         bt.logging.info("load_state()")
         self.load_state()
@@ -224,17 +230,13 @@ class Validator(ReinforcedValidatorNeuron):
     @step.setter
     def step(self, value):
         if value > 0:
-            if os.getenv("VALIDATOR_TIME", None):
-                validator_time = int(os.getenv("VALIDATOR_TIME"))
+            if self._validator_time_min:
                 current_minute = int(time.strftime("%M"))
-                if not 0 <= validator_time <= 59:
-                    raise ValueError("VALIDATOR_TIME has incorrect value!")
-
-                if current_minute == validator_time:
-                    wait_time = 3600
+                if current_minute == self._validator_time_min:
+                    wait_time_sec = 60
                 else:
-                    wait_time = (validator_time - current_minute) % 60
-                time.sleep(wait_time * 60)
+                    wait_time_sec = (self._validator_time_min - current_minute) % 60
+                time.sleep(wait_time_sec * 60)
             else:
                 elapsed_time = time.time() - self._start_time
                 if elapsed_time < CYCLE_TIME:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -35,7 +35,6 @@ CONTRACT_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..", "contract_templates"
 )
 PROVIDER = FileContractProvider(CONTRACT_DIR)
-CYCLE_TIME = 3600
 
 
 class Validator(ReinforcedValidatorNeuron):
@@ -43,12 +42,11 @@ class Validator(ReinforcedValidatorNeuron):
     WEIGHT_SCORE = 0.9
 
     def __init__(self, config=None):
+        self._step = 0
         super().__init__(config=config)
         bt.logging.info("load_state()")
         self.load_state()
         self.set_identity()
-        self._step = 0
-        self._start_time = time.time()
 
     async def forward(self):
         """
@@ -225,13 +223,19 @@ class Validator(ReinforcedValidatorNeuron):
     @step.setter
     def step(self, value):
         if value > 0:
-            end_time = time.time()
-            elapsed_time = end_time - self._start_time
-            if elapsed_time < CYCLE_TIME:
-                time.sleep(CYCLE_TIME - elapsed_time)
-        self._step = value
-        self._start_time = time.time()
+            current_minute = int(time.strftime('%M'))
+            validator_time = int(os.getenv("VALIDATOR_TIME"))
 
+            if validator_time < 0 or validator_time > 59:
+                raise ValueError("VALIDATOR_TIME has incorrect value!")
+
+            if current_minute == validator_time:
+                wait_time = 3600
+            else:
+                wait_time = (validator_time - current_minute) % 60
+            time.sleep(wait_time * 60)
+
+        self._step = value
 
 if __name__ == "__main__":
     load_dotenv()

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -233,10 +233,10 @@ class Validator(ReinforcedValidatorNeuron):
             if self._validator_time_min:
                 current_minute = int(time.strftime("%M"))
                 if current_minute == self._validator_time_min:
-                    wait_time_sec = 60
+                    wait_time_min = 60
                 else:
-                    wait_time_sec = (self._validator_time_min - current_minute) % 60
-                time.sleep(wait_time_sec * 60)
+                    wait_time_min = (self._validator_time_min - current_minute) % 60
+                time.sleep(wait_time_min * 60)
             else:
                 elapsed_time = time.time() - self._start_time
                 if elapsed_time < CYCLE_TIME:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -35,6 +35,7 @@ CONTRACT_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..", "contract_templates"
 )
 PROVIDER = FileContractProvider(CONTRACT_DIR)
+CYCLE_TIME = 3600
 
 
 class Validator(ReinforcedValidatorNeuron):
@@ -43,6 +44,7 @@ class Validator(ReinforcedValidatorNeuron):
 
     def __init__(self, config=None):
         self._step = 0
+        self._start_time = time.time()
         super().__init__(config=config)
         bt.logging.info("load_state()")
         self.load_state()
@@ -189,7 +191,7 @@ class Validator(ReinforcedValidatorNeuron):
             return 1.0
         else:
             return 0.0
-        
+
     def save_state(self):
         """Saves the state of the validator to a file."""
         bt.logging.info("Saving validator state.")
@@ -203,7 +205,6 @@ class Validator(ReinforcedValidatorNeuron):
 
         with open(self.config.neuron.full_path + "/state.pkl", "wb") as f:
             pickle.dump(state, f)
-
 
     def load_state(self):
         """Loads the state of the validator from a file."""
@@ -223,19 +224,25 @@ class Validator(ReinforcedValidatorNeuron):
     @step.setter
     def step(self, value):
         if value > 0:
-            current_minute = int(time.strftime('%M'))
-            validator_time = int(os.getenv("VALIDATOR_TIME"))
+            if os.getenv("VALIDATOR_TIME", None):
+                validator_time = int(os.getenv("VALIDATOR_TIME"))
+                current_minute = int(time.strftime("%M"))
+                if not 0 <= validator_time <= 59:
+                    raise ValueError("VALIDATOR_TIME has incorrect value!")
 
-            if validator_time < 0 or validator_time > 59:
-                raise ValueError("VALIDATOR_TIME has incorrect value!")
-
-            if current_minute == validator_time:
-                wait_time = 3600
+                if current_minute == validator_time:
+                    wait_time = 3600
+                else:
+                    wait_time = (validator_time - current_minute) % 60
+                time.sleep(wait_time * 60)
             else:
-                wait_time = (validator_time - current_minute) % 60
-            time.sleep(wait_time * 60)
+                elapsed_time = time.time() - self._start_time
+                if elapsed_time < CYCLE_TIME:
+                    time.sleep(CYCLE_TIME - elapsed_time)
+                self._start_time = time.time()
 
         self._step = value
+
 
 if __name__ == "__main__":
     load_dotenv()


### PR DESCRIPTION
Added a feature for validator scheduling that allows tasks to be sent at a specific minute of the hour. For example, if the `VALIDATOR_TIME` variable is set to 35, the validator will send tasks at HH:35 every hour.