### PR TITLE
AST without compilation + logging

### DIFF
--- a/ai_audits/contracts/contract_generator.py
+++ b/ai_audits/contracts/contract_generator.py
@@ -3,6 +3,7 @@ from typing import Union, List, Optional
 from openai import BaseModel
 from pydantic import ValidationError
 from solc_ast_parser import parse_ast_to_solidity
+from solc_ast_parser.utils import create_ast_with_standart_input, create_ast_from_source
 from solc_ast_parser.models.ast_models import (
     SourceUnit,
     VariableDeclaration,
@@ -10,17 +11,8 @@ from solc_ast_parser.models.ast_models import (
 )
 from solc_ast_parser.models.base_ast_models import NodeType
 from solc_ast_parser.models import ast_models
-import solcx
 
 from ai_audits.protocol import ValidatorTask, VulnerabilityReport, TaskType
-
-FILE_NAME = "contract.example.sol"
-
-
-def compile_contract_from_source(source: str):
-    suggested_version = solcx.install.select_pragma_version(source, solcx.get_installable_solc_versions())
-    json_compiled = solcx.compile_source(source, solc_version=suggested_version)
-    return json_compiled[list(json_compiled.keys())[0]]["ast"]
 
 
 def get_contract_nodes(ast: SourceUnit, node_type: NodeType = None) -> List[ast_models.ASTNode]:
@@ -129,16 +121,6 @@ def create_contract(pseudocode: str) -> str:
     return f"contract PseudoContract {{\n\n{pseudocode}\n}}"
 
 
-def create_ast_from_source(source: str) -> SourceUnit:
-    ast = compile_contract_from_source(source)
-    try:
-        return SourceUnit(**ast)
-    except ValidationError as e:
-        with open("contract.errors.txt", "w+") as f:
-            f.write(str(e))
-        raise e
-
-
 def insert_vulnerability_to_contract(
     contract_ast: SourceUnit,
     vulnerability_ast: SourceUnit,
@@ -147,8 +129,10 @@ def insert_vulnerability_to_contract(
     for node in vuln_nodes:
         if node.node_type == NodeType.FUNCTION_DEFINITION and node.kind == "constructor":
             continue
-        elif node.node_type == NodeType.FUNCTION_DEFINITION and check_node_in_contract(contract_ast, NodeType.FUNCTION_DEFINITION, name=node.name):
-                change_function_in_contract(contract_ast, node)
+        elif node.node_type == NodeType.FUNCTION_DEFINITION and check_node_in_contract(
+            contract_ast, NodeType.FUNCTION_DEFINITION, name=node.name
+        ):
+            change_function_in_contract(contract_ast, node)
         elif not check_node_in_contract(contract_ast, node.node_type, name=node.name):
             contract_ast = append_node_to_contract(contract_ast, node)
 
@@ -167,7 +151,8 @@ def create_task(
     ast_obj_contract = create_ast_from_source(contract_source)
 
     vulnerability_contract = create_contract(raw_vulnerability.code)
-    ast_obj_vulnerability = create_ast_from_source(vulnerability_contract)
+
+    ast_obj_vulnerability = create_ast_with_standart_input(vulnerability_contract)
 
     contract_source = insert_vulnerability_to_contract(ast_obj_contract, ast_obj_vulnerability)
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -224,7 +224,7 @@ class Validator(ReinforcedValidatorNeuron):
         axon_info = self.axon.info()
         dendrites = [x.dendrite for x in responses if x.dendrite.process_time is not None and x.axon.hotkey != axon_info.hotkey]
         
-        logging.debug(f"Axons response times: {[f"Miner with UUID {x.uuid}: {x.process_time}" for x in dendrites]}")
+        logging.debug(f"Axons response times: {[{x.uuid: x.process_time} for x in dendrites]}")
         
         times = [x.process_time for x in dendrites]
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -224,7 +224,7 @@ class Validator(ReinforcedValidatorNeuron):
         axon_info = self.axon.info()
         dendrites = [x.dendrite for x in responses if x.dendrite.process_time is not None and x.axon.hotkey != axon_info.hotkey]
         
-        logging.debug(f"Axons response times: {[{x.uuid: x.process_time} for x in dendrites]}")
+        logging.debug(f"Axons response times: {', '.join([f'{x.ip}:{x.port} - {x.process_time}' for x in dendrites])}")
         
         times = [x.process_time for x in dendrites]
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -137,7 +137,7 @@ class Validator(ReinforcedValidatorNeuron):
             deserialize=False,
             timeout=600,
         )
-        logging.info(f"Received responses: {responses}")
+        logging.info(f"Received responses: {[resp.response for resp in responses]}")
 
         rewards = self.validate_responses(responses, task)
 
@@ -222,22 +222,21 @@ class Validator(ReinforcedValidatorNeuron):
         task: ValidatorTask = None,
     ) -> List[float]:
         axon_info = self.axon.info()
-        times = [
-            x.dendrite.process_time
-            for x in responses
-            if x.dendrite.process_time is not None and x.axon.hotkey != axon_info.hotkey
-        ]
-        logging.debug(f"axons response times: {times}")
+        dendrites = [x.dendrite for x in responses if x.dendrite.process_time is not None and x.axon.hotkey != axon_info.hotkey]
+        
+        logging.debug(f"Axons response times: {[f"Miner with UUID {x.uuid}: {x.process_time}" for x in dendrites]}")
+        
+        times = [x.process_time for x in dendrites]
 
         min_time = min(times) if times else 0.0
 
-        logging.debug(f"minimal response time: {min_time}")
+        logging.debug(f"Minimal response time: {min_time}")
 
         scores: list[float] = []
 
         for synapse in responses:
             logging.debug(
-                f"synapse: axon hotkey: {synapse.axon.hotkey} | is success: {synapse.is_success} | "
+                f"Synapse: axon hotkey: {synapse.axon.hotkey} | is success: {synapse.is_success} | "
                 f"is blacklisted: {synapse.is_blacklist} | message: {synapse.axon.status_message}"
             )
             scores_by_report = self.validate_reports_by_reference(synapse.response, task) * self.WEIGHT_SCORE

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ setuptools==70
 python-dotenv==1.0.1
 openai==1.51.0
 py-solc-x==2.0.3
-solc_ast_parser==1.0.9
+solc_ast_parser==1.1.2
 hypothesis==6.124.9
 solidity-vulnerabilities-db<1
 websocket-client==1.8.0


### PR DESCRIPTION
* Removed the `compile_contract_from_source` and `create_ast_from_source` functions, and replaced their usage with `create_ast_with_standart_input` and `create_ast_from_source` from `solc_ast_parser.utils`. 
* Enhanced logging in the `async def forward(self)` method to log only the responses' content instead of the entire response objects.
* Refined the logging in the `validate_responses` method to include detailed dendrite information and improved formatting of the log messages.